### PR TITLE
Recognize ED25519 keys for automated $GitCredentialsFile config

### DIFF
--- a/GitLink/Kernel/GitLink.wl
+++ b/GitLink/Kernel/GitLink.wl
@@ -112,7 +112,7 @@ Block[{path, $LibraryPath = Join[$GitLibraryPath, $LibraryPath], libname},
 		
 		$GitLibrary = path;
 		If[!StringQ[$GitCredentialsFile], $GitCredentialsFile = SelectFirst[
-			FileNameJoin[{$HomeDirectory, ".ssh", #}] & /@ {"id_rsa", "id_dsa"},
+			FileNameJoin[{$HomeDirectory, ".ssh", #}] & /@ {"id_ed25519", "id_rsa", "id_dsa"},
 			FileExistsQ,
 			FileNameJoin[{$HomeDirectory, ".ssh", "id_rsa"}]
 		]];


### PR DESCRIPTION
Look for ED25519 key in the .ssh directory when auto configuring $GitCredentialsFile

In GitLab documentation they list ED25519 as the "preferred" type of key over DSA and RSA.